### PR TITLE
Fixes for nvim 0.9+

### DIFF
--- a/lua/cscope/cscope.lua
+++ b/lua/cscope/cscope.lua
@@ -103,7 +103,7 @@ local cscope_find_helper = function(op_n, op_s, symbol)
 
 	vim.fn.setqflist(parsed_output, "r")
 	vim.fn.setqflist({}, "a", { title = "cscope find " .. op_s .. " " .. symbol })
-	vim.api.nvim_command("copen")
+	vim.api.nvim_command("botright copen")
 end
 
 local cscope_find = function(op, symbol)

--- a/lua/cscope/cscope.lua
+++ b/lua/cscope/cscope.lua
@@ -161,7 +161,7 @@ M.setup = function(opts)
 	-- This variable can be used by other plugins to change db_file
 	-- e.g. vim-gutentags can use it for when
 	--	vim.g.gutentags_cache_dir is enabled.
-	vim.g.cscope_maps_db_file = ""
+	vim.g.cscope_maps_db_file = "./cscope.out"
 	cscope_user_command()
 end
 


### PR DESCRIPTION
Some changes which I required to get my setup working with nvim 0.9+.

1. Use default value of './cscope.out' for vim.g.cscope_maps_db_file, as the parameter was empy otherwise.
2. Use 'botright copen' instead of 'copen', since 'copen' alone doesn't display well with plugins like tagbar.
