### PR TITLE
Remove 2nd parameter to fs_stat

### DIFF
--- a/lua/cscope_maps.lua
+++ b/lua/cscope_maps.lua
@@ -131,7 +131,7 @@ M.setup = function(opts)
 	local cscope = "Cscope"
 
 	if is_supported_version() then
-		if vim.loop.fs_stat(M.opts.cscope.db_file, "r") ~= nil then
+		if vim.loop.fs_stat(M.opts.cscope.db_file) ~= nil then
 			inbuilt_cscope_opts()
 		end
 		cscope = "cscope"


### PR DESCRIPTION
I get this error on startup since a recent pull on my CentOS 8 server:
```
cscope_maps.nvim/lua/cscope_maps.lua:134: bad argument #2 to 'fs_stat' (function or callable table expected, got string)
```

In addition, the default opts in cscope.lua is not loaded, but I worked around this by setting them in my plugin init.lua.

Both of these problems only happens on my CentOS 8 machine. My Macbook works just fine with the same version of cscope_maps.nvim and nvim configuration.

This change removes the 2nd parameter.