### PR TITLE
fix not adding to tagstack when jump-return-jump case

### DIFF
--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -364,13 +364,17 @@ local cscope_project_root = function()
 		if vim.loop.fs_stat(path .. "/" .. M.opts.db_file) ~= nil then
 			return path
 		end
-		if path == "/" then
-			return nil
+		if vim.fn.has("win32") then
+			if path:len() <= 2 then
+				return nil
+			end
+			path = path:match("^(.*)[/\\]")
+		else
+			if path == "/" then
+				return nil
+			end
+			path = path:match("^(.*)/")
 		end
-		if vim.fn.has("win32") and path:len() <= 2 then
-			return nil
-		end
-		path = path:match("^(.*)[/\\]")
 	end
 end
 

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -364,10 +364,10 @@ local cscope_project_root = function()
 		if vim.loop.fs_stat(path .. "/" .. M.opts.db_file) ~= nil then
 			return path
 		end
-		if path == "/" then
+		if path:len() <= 2 then
 			return nil
 		end
-		path = path:match("^(.*)/")
+		path = path:match("^(.*)[/\\]")
 	end
 end
 

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -386,8 +386,20 @@ M.init_inbuilt_cscope = function(opts)
 	vim.opt.cscopeverbose = true
 	-- results in quickfix window
 	vim.opt.cscopequickfix = "s-,g-,c-,t-,e-,f-,i-,d-,a-"
-	-- add cscope database in current directory
-	vim.api.nvim_command("cs add " .. M.opts.db_file)
+
+	if M.opts.project_rooter.enable then
+		project_root = cscope_project_root()
+		if project_root ~= nil then
+			M.opts.db_file = project_root .. "/" .. M.opts.db_file
+			if M.opts.project_rooter.change_cwd then
+				vim.cmd("cd " .. project_root)
+			end
+		end
+	end
+
+	if vim.loop.fs_stat(M.opts.db_file) ~= nil then
+		vim.api.nvim_command("cs add " .. M.opts.db_file)
+	end
 end
 
 M.setup = function(opts)

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -62,7 +62,7 @@ local cscope_push_tagstack = function()
 	local from = { vim.fn.bufnr("%"), vim.fn.line("."), vim.fn.col("."), 0 }
 	local items = { { tagname = vim.fn.expand("<cword>"), from = from } }
 	local ts = vim.fn.gettagstack()
-	local ts_last_item = ts.items[ts.length]
+	local ts_last_item = ts.items[ts.curidx - 1]
 
 	if
 		ts_last_item

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -374,6 +374,22 @@ local cscope_project_root = function()
 	end
 end
 
+M.init_inbuilt_cscope = function(opts)
+	M.opts = vim.tbl_deep_extend("force", M.opts, opts)
+
+	-- use both cscope and ctag for 'ctrl-]', ':ta', and 'vim -t'
+	vim.opt.cscopetag = true
+	-- check cscope for definition of a symbol before checking ctags: set to 1
+	-- if you want the reverse search order.
+	vim.opt.csto = 0
+	-- show msg when cscope db added
+	vim.opt.cscopeverbose = true
+	-- results in quickfix window
+	vim.opt.cscopequickfix = "s-,g-,c-,t-,e-,f-,i-,d-,a-"
+	-- add cscope database in current directory
+	vim.api.nvim_command("cs add " .. M.opts.db_file)
+end
+
 M.setup = function(opts)
 	M.opts = vim.tbl_deep_extend("force", M.opts, opts)
 	-- This variable can be used by other plugins to change db_file

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -364,7 +364,10 @@ local cscope_project_root = function()
 		if vim.loop.fs_stat(path .. "/" .. M.opts.db_file) ~= nil then
 			return path
 		end
-		if path:len() <= 2 then
+		if path == "/" then
+			return nil
+		end
+		if vim.fn.has("win32") and path:len() <= 2 then
 			return nil
 		end
 		path = path:match("^(.*)[/\\]")

--- a/lua/cscope_maps.lua
+++ b/lua/cscope_maps.lua
@@ -16,9 +16,7 @@ M.setup = function(opts)
 	local cscope = "Cscope"
 
 	if helper.is_inbuilt_cscope() then
-		if vim.loop.fs_stat(M.opts.cscope.db_file) ~= nil then
-			require("cscope").init_inbuilt_cscope(M.opts.cscope)
-		end
+		require("cscope").init_inbuilt_cscope(M.opts.cscope)
 		cscope = "cscope"
 	else
 		-- Use cscope lua port

--- a/lua/cscope_maps.lua
+++ b/lua/cscope_maps.lua
@@ -17,7 +17,7 @@ M.setup = function(opts)
 
 	if helper.is_inbuilt_cscope() then
 		if vim.loop.fs_stat(M.opts.cscope.db_file) ~= nil then
-			helper.init_inbuilt_cscope(M.opts.cscope.db_file)
+			require("cscope").init_inbuilt_cscope(M.opts.cscope)
 		end
 		cscope = "cscope"
 	else

--- a/lua/cscope_maps.lua
+++ b/lua/cscope_maps.lua
@@ -17,7 +17,7 @@ M.setup = function(opts)
 
 	if helper.is_inbuilt_cscope() then
 		if vim.loop.fs_stat(M.opts.cscope.db_file) ~= nil then
-			helper.init_inbuilt_cscope()
+			helper.init_inbuilt_cscope(M.opts.cscope.db_file)
 		end
 		cscope = "cscope"
 	else

--- a/lua/utils/maps_helper.lua
+++ b/lua/utils/maps_helper.lua
@@ -3,7 +3,7 @@ local map = vim.keymap.set
 
 M.ver = vim.version()
 
-M.init_inbuilt_cscope = function()
+M.init_inbuilt_cscope = function(db_file)
 	-- use both cscope and ctag for 'ctrl-]', ':ta', and 'vim -t'
 	vim.opt.cscopetag = true
 	-- check cscope for definition of a symbol before checking ctags: set to 1
@@ -14,7 +14,7 @@ M.init_inbuilt_cscope = function()
 	-- results in quickfix window
 	vim.opt.cscopequickfix = "s-,g-,c-,t-,e-,f-,i-,d-,a-"
 	-- add cscope database in current directory
-	vim.api.nvim_command("cs add " .. M.opts.cscope.db_file)
+	vim.api.nvim_command("cs add " .. db_file)
 end
 
 M.is_inbuilt_cscope = function()

--- a/lua/utils/maps_helper.lua
+++ b/lua/utils/maps_helper.lua
@@ -3,20 +3,6 @@ local map = vim.keymap.set
 
 M.ver = vim.version()
 
-M.init_inbuilt_cscope = function(db_file)
-	-- use both cscope and ctag for 'ctrl-]', ':ta', and 'vim -t'
-	vim.opt.cscopetag = true
-	-- check cscope for definition of a symbol before checking ctags: set to 1
-	-- if you want the reverse search order.
-	vim.opt.csto = 0
-	-- show msg when cscope db added
-	vim.opt.cscopeverbose = true
-	-- results in quickfix window
-	vim.opt.cscopequickfix = "s-,g-,c-,t-,e-,f-,i-,d-,a-"
-	-- add cscope database in current directory
-	vim.api.nvim_command("cs add " .. db_file)
-end
-
 M.is_inbuilt_cscope = function()
 	-- cscope is removed from nvim 0.9+
 	return M.ver.major == 0 and M.ver.minor < 9


### PR DESCRIPTION
### Problem sequence
```
:Cscope find g main
normal <C-T>
:Cscope find g main 
normal <C-T>
```

The second 'find g' does not add a return point to the tagstack, So the second <C-T> returns to the wrong point.

### Fix
Should check which item is currently active, instead of the total length of the tagstack.