### PR TITLE
replace tag command with tjump

### DIFF
--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -256,7 +256,7 @@ local cscope_cstag = function(symbol)
 		return cscope_open_picker(op, symbol, res)
 	else
 		-- log.info("trying tags...")
-		if not pcall(vim.cmd.tag, symbol) then
+		if not pcall(vim.cmd.tjump, symbol) then
 			log.warn("Vim(tag):E426: tag not found: " .. symbol)
 			return RC.NO_RESULTS
 		end


### PR DESCRIPTION
```vimhelp
							*:cstag* *E257* *E562*
If you use cscope as well as ctags, |:cstag| allows you to search one or
the other before making a jump.  For example, you can choose to first
search your cscope database(s) for a match, and if one is not found, then
your tags file(s) will be searched.  The order in which this happens
is determined by the value of |csto|.  See |cscope-options| for more
details.

|:cstag| performs the equivalent of ":cs find g" on the identifier when
searching through the cscope database(s).

|:cstag| performs the equivalent of |:tjump| on the identifier when searching
through your tags file(s).
```