### PR TITLE
Add lua command before the require

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Following example uses [lazy.nvim](https://github.com/folke/lazy.nvim)
 ## Configuration
 
 You must run `require("cscope_maps").setup()` to initialize the plugin even when using default options.
-If you want to load the plugin from startup add `lua require("cscope_maps").setup()` to your `vimrc`.
+
+NOTE: In `vimrc` use `lua require("cscope_maps").setup()`
 
 _cscope_maps_ comes with following defaults:
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Following example uses [lazy.nvim](https://github.com/folke/lazy.nvim)
 ## Configuration
 
 You must run `require("cscope_maps").setup()` to initialize the plugin even when using default options.
+If you want to load the plugin from startup add `lua require("cscope_maps").setup()` to your `vimrc`.
 
 _cscope_maps_ comes with following defaults:
 


### PR DESCRIPTION
As solution described in #52 is to add `lua` in front of `require` command when you want to add the plugin to the `vimrc` this can be added to readme for future users.