### PR TITLE
cscope: fix default_keymaps not silent

### DIFF
--- a/lua/cscope_maps/utils/helper.lua
+++ b/lua/cscope_maps/utils/helper.lua
@@ -25,17 +25,17 @@ M.default_keymaps = function(prefix)
 			wk.register({ [prefix] = { name = "+cscope" } })
 		end
 	end
-	map("n", prefix .. "s", ":CsPrompt s<cr>", { desc = sym_map.s })
-	map("n", prefix .. "g", ":CsPrompt g<cr>", { desc = sym_map.g })
-	map("n", prefix .. "c", ":CsPrompt c<cr>", { desc = sym_map.c })
-	map("n", prefix .. "t", ":CsPrompt t<cr>", { desc = sym_map.t })
-	map("n", prefix .. "e", ":CsPrompt e<cr>", { desc = sym_map.e })
-	map("n", prefix .. "f", ":CsPrompt f<cr>", { desc = sym_map.f })
-	map("n", prefix .. "i", ":CsPrompt i<cr>", { desc = sym_map.i })
-	map("n", prefix .. "d", ":CsPrompt d<cr>", { desc = sym_map.d })
-	map("n", prefix .. "a", ":CsPrompt a<cr>", { desc = sym_map.a })
-	map("n", prefix .. "b", ":Cs db build<cr>", { desc = sym_map.b })
-	map("n", "<C-]>", ":Cstag<cr>", { noremap = true, silent = true, desc = "ctag" })
+	map("n", prefix .. "s", "<cmd>CsPrompt s<cr>", { desc = sym_map.s })
+	map("n", prefix .. "g", "<cmd>CsPrompt g<cr>", { desc = sym_map.g })
+	map("n", prefix .. "c", "<cmd>CsPrompt c<cr>", { desc = sym_map.c })
+	map("n", prefix .. "t", "<cmd>CsPrompt t<cr>", { desc = sym_map.t })
+	map("n", prefix .. "e", "<cmd>CsPrompt e<cr>", { desc = sym_map.e })
+	map("n", prefix .. "f", "<cmd>CsPrompt f<cr>", { desc = sym_map.f })
+	map("n", prefix .. "i", "<cmd>CsPrompt i<cr>", { desc = sym_map.i })
+	map("n", prefix .. "d", "<cmd>CsPrompt d<cr>", { desc = sym_map.d })
+	map("n", prefix .. "a", "<cmd>CsPrompt a<cr>", { desc = sym_map.a })
+	map("n", prefix .. "b", "<cmd>Cs db build<cr>", { desc = sym_map.b })
+	map("n", "<C-]>", "<cmd>Cstag<cr>", { noremap = true, silent = true, desc = "ctag" })
 end
 
 return M


### PR DESCRIPTION
Use ":" to enter command mode, not silent by default.
In addition to this, using `<CMD>...<CR>` has many advantages:
https://neovim.io/doc/user/map.html#%3CCmd%3E