### PR TITLE
cscope: project_rooter support for db_file with subdirs

### DIFF
--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -535,6 +535,19 @@ M.reload = function()
 	M.setup(M.user_opts)
 end
 
+M.root = function(source, marker)
+	if vim.fn.filereadable(vim.fs.joinpath(source, marker)) == 1 then
+		return source
+	end
+
+	for dir in vim.fs.parents(source) do
+		if vim.fn.filereadable(vim.fs.joinpath(dir, marker)) == 1 then
+			return dir
+		end
+	end
+	return nil
+end
+
 ---Initialization api
 ---@param opts CsConfig
 M.setup = function(opts)
@@ -564,7 +577,7 @@ M.setup = function(opts)
 	-- 2. if change_cwd is enabled, change into it (?)
 	if M.opts.project_rooter.enable then
 		local primary_conn = db.primary_conn()
-		local root = vim.fs.root(vim.fn.getcwd(), primary_conn.file)
+		local root = M.root(vim.fn.getcwd(), primary_conn.file)
 		if root then
 			db.update_primary_conn(vim.fs.joinpath(root, primary_conn.file), root)
 


### PR DESCRIPTION
If `project_rooter` has been enabled and the `db_file` contains one or more sub-directory components (e.g. '.cscope/cscope.out'), the root string returned by `vim.fs.root` will contain these sub-directories (e.g. 'project/root/.cscope').  This isn't the root of the project however and causes the db to be updated with an invalid value.

To fix this we can replace the use vim.fs.root with a simple module version that does not add sub-directories from the match.