### PR TITLE
cscope: db: feat: ability to provide custom script to build DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Heavily inspired by emacs' [xcscope.el](https://github.com/dkogan/xcscope.el).
 - `:Cs db add <space sepatated files>` add db file(s) to cscope search.
 - `:Cs db rm <space sepatated files>` remove db file(s) from cscope search.
 - `:Cs db show` show all db connections.
-- `:Cs db build` (re)builds db for primary db.
+- `:Cs db build` (re)builds db.
+  - if `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
+  - Custom script can be provided. This script with predefined args.
+    e.g. user script will be called as following -
+    `/user/provided/script -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`
 - `vim.g.cscope_maps_statusline_indicator` can be used in statusline to indicate ongoing db build.
 - DB path grammar
   - `db_file::db_pre_path` db_pre_path (prefix path) will be appended to cscope results.
@@ -108,8 +112,8 @@ _cscope_maps_ comes with following defaults:
     qf_window_pos = "bottom", -- "bottom", "right", "left" or "top"
     -- "true" does not open picker for single result, just JUMP
     skip_picker_for_single_result = false, -- "false" or "true"
-    -- these args are directly passed to "cscope -f <db_file> <args>"
-    db_build_cmd_args = { "-bqkv" },
+    -- custom script can be used for db build
+	db_build_cmd = { script = "default", args = { "-bqkv" } },
     -- statusline indicator, default is cscope executable
     statusline_indicator = nil,
     -- try to locate db_file in parent dir(s)
@@ -212,4 +216,3 @@ under cursor
 ```lua
 vim.keymap.set({ "n", "v" }, "<C-c><C-g>", "<cmd>Cs f g<cr>")
 ```
-

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Heavily inspired by emacs' [xcscope.el](https://github.com/dkogan/xcscope.el).
 - `:Cs db rm <space sepatated files>` remove db file(s) from cscope search.
 - `:Cs db show` show all db connections.
 - `:Cs db build` (re)builds db.
-  - if `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
-  - Custom script can be provided. This script with predefined args.
-    e.g. user script will be called as following -
-    `/user/provided/script -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`
+  - If `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
+    - e.g. `cscope -f ${db_file} ${db_build_cmd.args}` OR `gtags-cscope ${db_build_cmd.args}`
+  - Custom script can be provided using `db_build_cmd.script`. Example script is [here](https://github.com/dhananjaylatkar/cscope_maps.nvim/pull/67)
+    - e.g. user script will be called as following -
+    - `${db_build_cmd.script} ${db_build_cmd.args} -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`
 - `vim.g.cscope_maps_statusline_indicator` can be used in statusline to indicate ongoing db build.
 - DB path grammar
   - `db_file::db_pre_path` db_pre_path (prefix path) will be appended to cscope results.

--- a/doc/cscope_maps.txt
+++ b/doc/cscope_maps.txt
@@ -55,10 +55,11 @@ CSCOPE DB ~
 - `:Cs db rm <space sepatated files>` remove db file(s) from cscope search.
 - `:Cs db show` show all db connections.
 - `:Cs db build` (re)builds db.
-    - if `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
-    - Custom script can be provided. This script with predefined args.
-        e.g. user script will be called as following -
-        `/user/provided/script -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`
+    - If `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
+        - e.g. `cscope -f ${db_file} ${db_build_cmd.args}` OR `gtags-cscope ${db_build_cmd.args}`
+    - Custom script can be provided using `db_build_cmd.script`. Example script is here <https://github.com/dhananjaylatkar/cscope_maps.nvim/pull/67>
+        - e.g. user script will be called as following -
+        - `${db_build_cmd.script} ${db_build_cmd.args} -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`
 - `vim.g.cscope_maps_statusline_indicator` can be used in statusline to indicate ongoing db build.
 - DB path grammar
     - `db_file::db_pre_path` db_pre_path (prefix path) will be appended to cscope results.

--- a/doc/cscope_maps.txt
+++ b/doc/cscope_maps.txt
@@ -1,4 +1,4 @@
-*cscope_maps.txt*      For Neovim >= v0.10.0     Last change: 2024 November 01
+*cscope_maps.txt*      For Neovim >= v0.10.0      Last change: 2025 January 12
 
 ==============================================================================
 Table of Contents                              *cscope_maps-table-of-contents*
@@ -54,7 +54,11 @@ CSCOPE DB ~
 - `:Cs db add <space sepatated files>` add db file(s) to cscope search.
 - `:Cs db rm <space sepatated files>` remove db file(s) from cscope search.
 - `:Cs db show` show all db connections.
-- `:Cs db build` (re)builds db for primary db.
+- `:Cs db build` (re)builds db.
+    - if `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
+    - Custom script can be provided. This script with predefined args.
+        e.g. user script will be called as following -
+        `/user/provided/script -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`
 - `vim.g.cscope_maps_statusline_indicator` can be used in statusline to indicate ongoing db build.
 - DB path grammar
     - `db_file::db_pre_path` db_pre_path (prefix path) will be appended to cscope results.
@@ -131,8 +135,8 @@ _cscope_maps_ comes with following defaults:
         qf_window_pos = "bottom", -- "bottom", "right", "left" or "top"
         -- "true" does not open picker for single result, just JUMP
         skip_picker_for_single_result = false, -- "false" or "true"
-        -- these args are directly passed to "cscope -f <db_file> <args>"
-        db_build_cmd_args = { "-bqkv" },
+        -- custom script can be used for db build
+        db_build_cmd = { script = "default", args = { "-bqkv" } },
         -- statusline indicator, default is cscope executable
         statusline_indicator = nil,
         -- try to locate db_file in parent dir(s)


### PR DESCRIPTION
- if `db_build_cmd.script == "default"` then only primary DB will be built using cscope binary.
- Custom script can be provided.
    e.g. user script will be called as following -
    `/user/provided/script -d <db1>::<pre_path1> -d <db2>::<pre_path2> ...`

Custom script example -
```bash
#!/usr/bin/env bash

DB_FILES=()
DB_ROOTS=()
while getopts "d:" opt; do
    case $opt in
        d)
            DB_FILES=("${DB_FILES[@]}" $(echo $OPTARG | awk -F:: '{print $1}'))
            DB_ROOTS=("${DB_ROOTS[@]}" $(echo $OPTARG | awk -F:: '{print $2}'))
            ;;
        esac
done

for ((i=0;i<${#DB_FILES[@]};i++))
do
    pushd ${DB_ROOTS[$i]}
    fd -e c -e h > cscope.files
    cscope -bqkv -f ${DB_FILES[$i]}
    popd
done

exit 0

```