### PR TITLE
Move the default db_build warning

### DIFF
--- a/lua/cscope/db.lua
+++ b/lua/cscope/db.lua
@@ -154,6 +154,7 @@ M.get_build_cmd = function(opts)
 	local cmd = {}
 
 	if opts.db_build_cmd.script == "default" then
+		log.info("Using default db_build script")
 		if opts.exec == "cscope" then
 			cmd = { "cscope", "-f", M.primary_conn().file }
 		else -- "gtags-cscope"

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -506,7 +506,6 @@ M.setup = function(opts)
 	end
 
 	if vim.fn.executable(M.opts.db_build_cmd.script) ~= 1 then
-		log.warn("db_build script is not found. Using default")
 		M.opts.db_build_cmd.script = "default"
 	end
 


### PR DESCRIPTION
The warning shows every time when nvim starts, which is annoying.
Change the log level to info and move it when building the db.
