### PR TITLE
Add picker for snacks.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Heavily inspired by emacs' [xcscope.el](https://github.com/dkogan/xcscope.el).
 - Supports `cscope` and `gtags-cscope`. Use `cscope.exec` option to specify executable.
 - Keymaps can be disabled using `disable_maps` option.
 - `:CsPrompt <op>` can be used to invoke cscope prompt.
-- Display results in quickfix, **telescope**, **fzf-lua** or **mini.pick**.
+- Display results in quickfix, **telescope**, **fzf-lua**, **mini.pick** or **snacks.nvim**.
 - Has [which-key.nvim](https://github.com/folke/which-key.nvim) and [mini.clue](https://github.com/echasnovski/mini.clue) hints.
 - See [this section](#vim-gutentags) for `vim-gutentags`.
 
@@ -74,6 +74,7 @@ Following example uses [lazy.nvim](https://github.com/folke/lazy.nvim)
     "nvim-telescope/telescope.nvim", -- optional [for picker="telescope"]
     "ibhagwan/fzf-lua", -- optional [for picker="fzf-lua"]
     "echasnovski/mini.pick", -- optional [for picker="mini-pick"]
+    "folke/snacks.nvim", -- optional [for picker="snacks"]
   },
   opts = {
     -- USE EMPTY FOR DEFAULT OPTIONS
@@ -108,7 +109,7 @@ _cscope_maps_ comes with following defaults:
     -- cscope executable
     exec = "cscope", -- "cscope" or "gtags-cscope"
     -- choose your fav picker
-    picker = "quickfix", -- "quickfix", "telescope", "fzf-lua" or "mini-pick"
+    picker = "quickfix", -- "quickfix", "telescope", "fzf-lua", "mini-pick" or "snacks"
     -- size of quickfix window
     qf_window_size = 5, -- any positive integer
     -- position of quickfix window

--- a/lua/cscope/pickers/snacks.lua
+++ b/lua/cscope/pickers/snacks.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+local prepare = function(items)
+	local res = {}
+	for i, item in ipairs(items) do
+		table.insert(res, {
+			file = item["filename"],
+			score = i,
+			text = item["text"],
+			line = item["text"],
+			pos = { tonumber(item["lnum"]), 0 },
+		})
+	end
+
+	return res
+end
+
+M.run = function(opts)
+	Snacks.picker({
+		items = prepare(opts.cscope.parsed_output),
+		title = opts.cscope.prompt_title,
+	})
+end
+
+return M


### PR DESCRIPTION
LazyVim has now moved to snacks.nvim for default picker. Adding snacks picker for cscope for people want to be in sync with defaults.