### PR TITLE
stackview: fix slow highlight behavior

### DIFF
--- a/lua/cscope/stack_view/hl.lua
+++ b/lua/cscope/stack_view/hl.lua
@@ -63,20 +63,26 @@ M.refresh = function(buf, root)
 	if vim.bo.filetype ~= M.ft then
 		return
 	end
-	local ancestors = tree.get_ancestors(root, fn.line("."))
 
 	local ns = api.nvim_create_namespace("CsStackViewHighlight")
 
 	local buf_lnum_start = fn.line("w0") - 1
-	local buf_lnum_end = fn.line("w$")
-	local buf_lnum = buf_lnum_start
+	local buf_lnum_end = fn.line("w$") - 1
+	local cursor_lnum = fn.line(".") - 1
+
+	local min_indent = vim.fn.indent(cursor_lnum)
 
 	api.nvim_buf_clear_namespace(buf, ns, 0, -1)
 
-	while buf_lnum < buf_lnum_end do
+	-- go from cursor up and highlight every place where the indentation gets smaller
+	for buf_lnum = cursor_lnum, buf_lnum_start, -1 do
+		local index_indent = vim.fn.indent(buf_lnum + 1)
 		if buf_lnum == 0 then
-			api.nvim_buf_add_highlight(buf, ns, "Function", buf_lnum, 0, -1)
-		elseif vim.tbl_contains(ancestors, buf_lnum + 1) then
+			-- always highlight the first line
+			api.nvim_buf_add_highlight(buf, ns, "Function", 0, 0, -1)
+		elseif (buf_lnum == cursor_lnum) or (index_indent < min_indent) then
+			-- highlight the cursor line and all the lines above it whose indentation is smaller than its previous line
+			min_indent = index_indent
 			local indicator_s, indicator_e, symbol_s, symbol_e, bo_s, bo_e, fname_s, fname_e, delim_s, delim_e, lnum_s, lnum_e, bc_s, bc_e =
 				M.get_pos(buf_lnum + 1)
 			api.nvim_buf_add_highlight(buf, ns, "Operator", buf_lnum, indicator_s, indicator_e)
@@ -87,9 +93,14 @@ M.refresh = function(buf, root)
 			api.nvim_buf_add_highlight(buf, ns, "Number", buf_lnum, lnum_s, lnum_e)
 			api.nvim_buf_add_highlight(buf, ns, "Delimiter", buf_lnum, bc_s, bc_e)
 		else
+			-- all the rest are comments
 			api.nvim_buf_add_highlight(buf, ns, "Comment", buf_lnum, 0, -1)
 		end
-		buf_lnum = buf_lnum + 1
+	end
+
+	-- all the lines below the cursor are comments for sure
+	for buf_lnum = cursor_lnum + 1, buf_lnum_end do
+		api.nvim_buf_add_highlight(buf, ns, "Comment", buf_lnum, 0, -1)
 	end
 end
 

--- a/lua/cscope/stack_view/tree.lua
+++ b/lua/cscope/stack_view/tree.lua
@@ -75,28 +75,4 @@ M.update_node = function(root, parent_id, children)
 	return nil
 end
 
-M.get_ancestors = function(root, node_id)
-	if root.id == node_id then
-		return { root.id }
-	end
-
-	local st = { { root } }
-	while #st ~= 0 do
-		local cur_path = table.remove(st, 1)
-		local cur_node = cur_path[#cur_path]
-		if cur_node.children then
-			for _, c in ipairs(cur_node.children) do
-				table.insert(cur_path, c)
-				if c.id == node_id then
-					return vim.tbl_map(function(x)
-						return x.id
-					end, cur_path)
-				end
-				table.insert(st, vim.deepcopy(cur_path))
-				table.remove(cur_path)
-			end
-		end
-	end
-end
-
 return M


### PR DESCRIPTION
fix the slowness caused by stackview highlight that happens when going down the stack when the stack tree contains wide levels (it doesn't have to be deep for it to happen).

the main performance bottleneck was due to the use of deepcopy during every path evaluation in the tree traversal.
when a path included 'wide nodes' (nodes with many children), repeatedly performing deep copies in each iteration caused significant slowdowns, often making NVIM appear unresponsive

the fix is indentation-based and only operates on the visible lines in the buffer and doesn't depend on the structure of the tree: all it does is to highlight the lines above the cursor every time the indentation gets smaller.