### PR TITLE
quickfix/location: fix unsaved history

### DIFF
--- a/lua/cscope/pickers/location.lua
+++ b/lua/cscope/pickers/location.lua
@@ -3,7 +3,7 @@ local M = {}
 M.run = function(opts)
 	local pos_cmd = ""
 
-	vim.fn.setloclist(0, opts.cscope.parsed_output, "r")
+	vim.fn.setloclist(0, opts.cscope.parsed_output)
 	vim.fn.setloclist(0, {}, "a", { title = opts.cscope.prompt_title })
 
 	if opts.cscope.picker_opts.window_pos == "top" then

--- a/lua/cscope/pickers/quickfix.lua
+++ b/lua/cscope/pickers/quickfix.lua
@@ -5,7 +5,7 @@ M.run = function(opts)
 	local window_size = opts.cscope.qf_window_size or opts.cscope.picker_opts.window_size
 	local window_pos = opts.cscope.qf_window_pos or opts.cscope.picker_opts.window_pos
 
-	vim.fn.setqflist(opts.cscope.parsed_output, "r")
+	vim.fn.setqflist(opts.cscope.parsed_output)
 	vim.fn.setqflist({}, "a", { title = opts.cscope.prompt_title })
 
 	if window_pos == "top" then


### PR DESCRIPTION
new cscope commands are expected to have a new list on the stack and not to override the current list - preventing from returning to it later.

fix that by removing the "r" ("replace") option from the setqflist/setloclist command and by that using the default option instead, which creates a new list on top of the stack lists.