### PR TITLE
fix Windows compatibility issue with is_path_abs()

### DIFF
--- a/lua/cscope_maps/utils/init.lua
+++ b/lua/cscope_maps/utils/init.lua
@@ -4,7 +4,7 @@ local M = {}
 ---@param path string
 ---@return boolean
 M.is_path_abs = function(path)
-	return vim.startswith(path, "/")
+	return vim.fn.isabsolutepath(path) == 1
 end
 
 --- Get relative path


### PR DESCRIPTION
There is a problem processing the cscope.out file created with a relative path in Windows.
It works fine in my use case with this simple modification.