### PR TITLE
cscope_maps: notify when empty input

### DIFF
--- a/lua/cscope_maps/init.lua
+++ b/lua/cscope_maps/init.lua
@@ -1,5 +1,6 @@
 local helper = require("cscope_maps.utils.helper")
 local cs = require("cscope")
+local log = require("cscope_maps.utils.log")
 local M = {}
 
 ---@class CsMapsConfig
@@ -37,8 +38,10 @@ M.cscope_prompt = function(operation)
 			end
 			if new_symbol ~= "" then
 				vim.cmd.Cscope({ args = { "find", operation, new_symbol } })
-			else
+			elseif default_symbol ~= "" then
 				vim.cmd.Cscope({ args = { "find", operation, default_symbol } })
+			else
+				log.warn("empty input")
 			end
 		end)
 	end

--- a/lua/cscope_maps/utils/log.lua
+++ b/lua/cscope_maps/utils/log.lua
@@ -33,7 +33,7 @@ M.trace = function(msg, hide)
 	if hide then
 		return
 	end
-	vim.notify("cscope: " .. msg, M.lvl.trace)
+	vim.notify("cscope: " .. msg, M.lvl.TRACE)
 end
 
 M.warn = function(msg, hide)


### PR DESCRIPTION
when `new_symbol` and `default_symbol` both are empty string, neovim will send a ERROR notify like this:

<img width="1456" height="296" alt="Screenshot From 2026-05-28 14-24-57" src="https://github.com/user-attachments/assets/8c8d84c6-0ba1-456b-ba4d-f6f03d8e1f23" />

I handle this, but I'm not sure should I send a warn notify or just silent.

Fix some warning from LSP.