### PR TITLE
feat: support cscope and gtags-cscope simultaneously via exec parameter 

### DIFF
--- a/lua/cscope/db.lua
+++ b/lua/cscope/db.lua
@@ -5,12 +5,14 @@ local M = {}
 
 --- conns = { {file = db_file, pre_path = db_pre_path}, ... }
 M.conns = {}
+M.gtags_conns = {}
 M.global_conn = nil
 
 M.sep = "::"
 
 M.reset = function()
 	M.conns = {}
+	M.gtags_conns = {}
 	M.global_conn = nil
 end
 
@@ -39,6 +41,38 @@ end
 M.update_primary_conn = function(file, pre_path)
 	M.conns[1].file = vim.fs.normalize(file)
 	M.conns[1].pre_path = vim.fs.normalize(pre_path)
+end
+
+---Add gtags db connection
+---@param path string
+M.add_gtags = function(path)
+	local file, pre_path = M.sp_file_pre_path(path)
+	for _, conn in ipairs(M.gtags_conns) do
+		if
+			utils.is_path_same(conn.file, file)
+			and (utils.is_path_same(conn.pre_path, pre_path) or conn.pre_path == nil)
+		then
+			return
+		end
+	end
+	table.insert(M.gtags_conns, { file = file, pre_path = pre_path })
+end
+
+---Get primary gtags db connection
+---@return table|nil
+M.primary_gtags_conn = function()
+	if #M.gtags_conns == 0 then
+		return nil
+	end
+	return M.gtags_conns[1]
+end
+
+---Update primary gtags db connection
+---@param file string
+---@param pre_path string
+M.update_primary_gtags_conn = function(file, pre_path)
+	M.gtags_conns[1].file = vim.fs.normalize(file)
+	M.gtags_conns[1].pre_path = vim.fs.normalize(pre_path)
 end
 
 ---Update global db connection
@@ -132,70 +166,106 @@ M.update = function(op, files)
 end
 
 M.print_conns = function()
-	if not M.conns then
+	if #M.conns == 0 and #M.gtags_conns == 0 then
 		log.warn("No connections")
+		return
 	end
 
 	for i, conn in ipairs(M.conns) do
 		local file = utils.get_rel_path(vim.fn.getcwd(), conn.file)
 		local pre_path = utils.get_rel_path(vim.fn.getcwd(), conn.pre_path)
 		if not pre_path or pre_path == "" then
-			log.warn(string.format("%d) db=%s", i, file))
+			log.warn(string.format("%d) [cscope] db=%s", i, file))
 		else
-			log.warn(string.format("%d) db=%s pre_path=%s", i, file, pre_path))
+			log.warn(string.format("%d) [cscope] db=%s pre_path=%s", i, file, pre_path))
+		end
+	end
+
+	for i, conn in ipairs(M.gtags_conns) do
+		local file = utils.get_rel_path(vim.fn.getcwd(), conn.file)
+		local pre_path = utils.get_rel_path(vim.fn.getcwd(), conn.pre_path)
+		if not pre_path or pre_path == "" then
+			log.warn(string.format("%d) [gtags] db=%s", i, file))
+		else
+			log.warn(string.format("%d) [gtags] db=%s pre_path=%s", i, file, pre_path))
 		end
 	end
 end
 
----Create command to build DB
----1. If script is default then use opt.exec
+---Create commands to build DB for all exec types
+---1. If script is default then build for each exec type
 ---2. If custom script is provided then use that with "-d <db>::<pre_path>" args
-M.get_build_cmd = function(opts)
-	local cmd = {}
+---@param opts table
+---@param exec_list string[]
+---@return table[]
+M.get_build_cmds = function(opts, exec_list)
+	local cmds = {}
 
 	if opts.db_build_cmd.script == "default" then
-		if opts.exec == "cscope" then
-			cmd = { "cscope", "-f", M.primary_conn().file }
-		else -- "gtags-cscope"
-			cmd = { "gtags-cscope" }
+		for _, exec in ipairs(exec_list) do
+			local cmd = {}
+			if exec == "cscope" then
+				local pc = M.primary_conn()
+				if pc then
+					cmd = { "cscope", "-f", pc.file }
+					vim.list_extend(cmd, opts.db_build_cmd.args)
+					table.insert(cmds, cmd)
+				end
+			elseif exec == "gtags-cscope" then
+				cmd = { "gtags-cscope" }
+				vim.list_extend(cmd, opts.db_build_cmd.args)
+				table.insert(cmds, cmd)
+			end
 		end
-
-		vim.list_extend(cmd, opts.db_build_cmd.args)
-		return cmd
+		return cmds
 	end
 
 	-- custom script
-	cmd = { opts.db_build_cmd.script }
+	local cmd = { opts.db_build_cmd.script }
 	vim.list_extend(cmd, opts.db_build_cmd.args)
 
 	for _, conn in ipairs(M.conns) do
 		vim.list_extend(cmd, { "-d", string.format("%s::%s", conn.file, conn.pre_path) })
 	end
 
-	return cmd
+	table.insert(cmds, cmd)
+	return cmds
 end
 
-local on_exit = function(obj)
-	vim.g.cscope_maps_statusline_indicator = nil
-	if obj.code == 0 then
-		-- print("cscope: [build] out: " .. obj.stdout)
-		print("cscope: database built successfully")
-	else
-		-- print("cscope: [build] out: " .. obj.stderr)
-		print("cscope: database build failed")
-	end
-end
-
-M.build = function(opts)
+M.build = function(opts, exec_list)
 	if vim.g.cscope_maps_statusline_indicator then
 		log.warn("db build is already in progress")
 		return
 	end
 
-	local cmd = M.get_build_cmd(opts)
+	local cmds = M.get_build_cmds(opts, exec_list)
+	if #cmds == 0 then
+		log.warn("no build commands to run")
+		return
+	end
 
-	vim.g.cscope_maps_statusline_indicator = opts.statusline_indicator or opts.exec
-	vim.system(cmd, { text = true }, on_exit)
+	local total = #cmds
+	local completed = 0
+	local failed = false
+
+	vim.g.cscope_maps_statusline_indicator = opts.statusline_indicator or table.concat(exec_list, "+")
+
+	for _, cmd in ipairs(cmds) do
+		vim.system(cmd, { text = true }, function(obj)
+			completed = completed + 1
+			if obj.code ~= 0 then
+				failed = true
+			end
+			if completed == total then
+				vim.g.cscope_maps_statusline_indicator = nil
+				if failed then
+					print("cscope: database build failed")
+				else
+					print("cscope: database built successfully")
+				end
+			end
+		end)
+	end
 end
 
 return M

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -16,7 +16,7 @@ local M = {}
 
 ---@class CsConfig
 ---@field db_file? string|[string]
----@field exec? string
+---@field exec? string|string[]
 ---@field picker? string
 ---@field skip_picker_for_single_result? boolean
 ---@field db_build_cmd? table
@@ -45,6 +45,7 @@ M.opts = {
 }
 
 M.user_opts = {}
+M.exec_list = {}
 
 -- operation symbol to number map
 M.op_s_n = {
@@ -191,15 +192,14 @@ end
 M.get_result = function(op_n, op_s, symbol, hide_log)
 	-- Executes cscope search and return parsed output
 
-	local db_conns = db.all_conns()
 	local res = {}
 
-	local exec_and_update_res = function(_db_con, _cmd_args)
+	local exec_and_update_res = function(_exec, _db_con, _cmd_args)
 		if vim.loop.fs_stat(_db_con.file) == nil then
 			return
 		end
 		local cmd = {
-			M.opts.exec,
+			_exec,
 			"-dL",
 			"-" .. op_n,
 			symbol,
@@ -217,19 +217,41 @@ M.get_result = function(op_n, op_s, symbol, hide_log)
 		res = vim.list_extend(res, M.parse_output(proc.stdout, _db_con.pre_path))
 	end
 
-	if M.opts.exec == "cscope" then
-		for _, db_con in ipairs(db_conns) do
-			exec_and_update_res(db_con, {})
+	local any_exec_supported = false
+
+	-- Prioritize gtags-cscope over cscope: query gtags first, then cscope
+	local ordered_exec_list = {}
+	for _, exec in ipairs(M.exec_list) do
+		if exec == "gtags-cscope" then
+			table.insert(ordered_exec_list, 1, exec)
+		else
+			table.insert(ordered_exec_list, exec)
 		end
-	elseif M.opts.exec == "gtags-cscope" then
-		if op_s == "d" then
-			log.warn("'d' operation is not available for " .. M.opts.exec, hide_log)
-			return RC.INVALID_OP, nil
+	end
+
+	for _, exec in ipairs(ordered_exec_list) do
+		if exec == "cscope" then
+			any_exec_supported = true
+			local db_conns = db.all_conns()
+			for _, db_con in ipairs(db_conns) do
+				exec_and_update_res(exec, db_con, {})
+			end
+		elseif exec == "gtags-cscope" then
+			if op_s ~= "d" then
+				any_exec_supported = true
+				local gtags_conn = db.primary_gtags_conn()
+				if gtags_conn then
+					exec_and_update_res(exec, gtags_conn, { "-a" })
+				end
+			end
+		else
+			log.warn("'" .. exec .. "' executable is not supported", hide_log)
 		end
-		exec_and_update_res(db.primary_conn(), { "-a" })
-	else
-		log.warn("'" .. M.opts.exec .. "' executable is not supported", hide_log)
-		return RC.INVALID_EXEC, nil
+	end
+
+	if not any_exec_supported then
+		log.warn("'" .. op_s .. "' operation is not available for configured executables", hide_log)
+		return RC.INVALID_OP, nil
 	end
 
 	if vim.tbl_isempty(res) then
@@ -412,7 +434,7 @@ M.run = function(args)
 
 		local op = args[2]:sub(1, 1)
 		if op == "b" then
-			db.build(M.opts)
+			db.build(M.opts, M.exec_list)
 		elseif op == "a" or op == "r" then
 			-- collect all args
 			local files = {}
@@ -576,16 +598,32 @@ M.setup = function(opts)
 	vim.g.cscope_maps_db_file = nil
 	vim.g.cscope_maps_statusline_indicator = nil
 
-	if M.opts.exec == "gtags-cscope" then
+	-- Normalize exec to a list
+	if type(M.opts.exec) == "string" then
+		M.exec_list = { M.opts.exec }
+	else
+		M.exec_list = vim.deepcopy(M.opts.exec)
+	end
+
+	-- For backward compat: single gtags-cscope forces db_file to GTAGS
+	if #M.exec_list == 1 and M.exec_list[1] == "gtags-cscope" then
 		M.opts.db_file = gtags_db
 	end
 
-	if type(M.opts.db_file) == "string" then
-		db.add(M.opts.db_file)
-	else -- table
-		for _, f in ipairs(M.opts.db_file) do
-			db.add(f)
+	-- Add cscope db connections
+	if vim.tbl_contains(M.exec_list, "cscope") then
+		if type(M.opts.db_file) == "string" then
+			db.add(M.opts.db_file)
+		else
+			for _, f in ipairs(M.opts.db_file) do
+				db.add(f)
+			end
 		end
+	end
+
+	-- Add gtags db connections
+	if vim.tbl_contains(M.exec_list, "gtags-cscope") then
+		db.add_gtags(gtags_db)
 	end
 
 	if M.opts.db_build_cmd.script ~= "default" and vim.fn.executable(M.opts.db_build_cmd.script) ~= 1 then
@@ -607,14 +645,32 @@ M.setup = function(opts)
 	-- 1. get root of project and update primary conn
 	-- 2. if change_cwd is enabled, change into it (?)
 	if M.opts.project_rooter.enable then
-		local primary_conn = db.primary_conn()
-		local root = M.root(vim.fn.getcwd(), primary_conn.file)
-		if root then
-			db.update_primary_conn(vim.fs.joinpath(root, primary_conn.file), root)
+		local root_found = nil
 
-			if M.opts.project_rooter.change_cwd then
-				vim.cmd("cd " .. root)
+		if vim.tbl_contains(M.exec_list, "cscope") then
+			local primary_conn = db.primary_conn()
+			if primary_conn then
+				local root = M.root(vim.fn.getcwd(), primary_conn.file)
+				if root then
+					db.update_primary_conn(vim.fs.joinpath(root, primary_conn.file), root)
+					root_found = root_found or root
+				end
 			end
+		end
+
+		if vim.tbl_contains(M.exec_list, "gtags-cscope") then
+			local gtags_conn = db.primary_gtags_conn()
+			if gtags_conn then
+				local root = M.root(vim.fn.getcwd(), gtags_conn.file)
+				if root then
+					db.update_primary_gtags_conn(vim.fs.joinpath(root, gtags_conn.file), root)
+					root_found = root_found or root
+				end
+			end
+		end
+
+		if root_found and M.opts.project_rooter.change_cwd then
+			vim.cmd("cd " .. root_found)
 		end
 	end
 

--- a/lua/cscope/init.lua
+++ b/lua/cscope/init.lua
@@ -217,7 +217,8 @@ M.get_result = function(op_n, op_s, symbol, hide_log)
 		res = vim.list_extend(res, M.parse_output(proc.stdout, _db_con.pre_path))
 	end
 
-	local any_exec_supported = false
+	local any_valid_exec = false
+	local any_op_supported = false
 
 	-- Prioritize gtags-cscope over cscope: query gtags first, then cscope
 	local ordered_exec_list = {}
@@ -231,14 +232,16 @@ M.get_result = function(op_n, op_s, symbol, hide_log)
 
 	for _, exec in ipairs(ordered_exec_list) do
 		if exec == "cscope" then
-			any_exec_supported = true
+			any_valid_exec = true
+			any_op_supported = true
 			local db_conns = db.all_conns()
 			for _, db_con in ipairs(db_conns) do
 				exec_and_update_res(exec, db_con, {})
 			end
 		elseif exec == "gtags-cscope" then
+			any_valid_exec = true
 			if op_s ~= "d" then
-				any_exec_supported = true
+				any_op_supported = true
 				local gtags_conn = db.primary_gtags_conn()
 				if gtags_conn then
 					exec_and_update_res(exec, gtags_conn, { "-a" })
@@ -249,9 +252,26 @@ M.get_result = function(op_n, op_s, symbol, hide_log)
 		end
 	end
 
-	if not any_exec_supported then
+	if not any_valid_exec then
+		return RC.INVALID_EXEC, nil
+	end
+
+	if not any_op_supported then
 		log.warn("'" .. op_s .. "' operation is not available for configured executables", hide_log)
 		return RC.INVALID_OP, nil
+	end
+
+	do
+		local seen = {}
+		local deduped = {}
+		for _, entry in ipairs(res) do
+			local key = table.concat({ entry.filename or "", entry.lnum or "" }, "\0")
+			if not seen[key] then
+				seen[key] = true
+				table.insert(deduped, entry)
+			end
+		end
+		res = deduped
 	end
 
 	if vim.tbl_isempty(res) then
@@ -603,11 +623,6 @@ M.setup = function(opts)
 		M.exec_list = { M.opts.exec }
 	else
 		M.exec_list = vim.deepcopy(M.opts.exec)
-	end
-
-	-- For backward compat: single gtags-cscope forces db_file to GTAGS
-	if #M.exec_list == 1 and M.exec_list[1] == "gtags-cscope" then
-		M.opts.db_file = gtags_db
 	end
 
 	-- Add cscope db connections


### PR DESCRIPTION
This PR aims to support cscope and gtags-cscope simultaneously via exec parameter.

For example:
```
cscope = {
  exec = { "cscope", "gtags-cscope" },
},
```